### PR TITLE
Adds initialFen attribute to GameStateEvent.Full

### DIFF
--- a/src/main/chariot/chariot/internal/ModelMapper.java
+++ b/src/main/chariot/chariot/internal/ModelMapper.java
@@ -806,12 +806,13 @@ public class ModelMapper {
                     String id = yo.getString("id");
                     GameType gameType = gameTypeMapper.apply(yo);
                     ZonedDateTime createdAt = Util.fromLong(yo.getLong("createdAt"));
+                    String initialFen = yo.getString("initialFen");
                     GameStateEvent.Side white = sideMapper.apply(yo.value().get("white"));
                     GameStateEvent.Side black = sideMapper.apply(yo.value().get("black"));
                     Opt<TournamentId> tournamentId = Opt.of(yo.getString("tournamentId")).map(TournamentId.ArenaId::new);
                     var state = gameStateEventStateMapper.apply(yo.value().get("state"));
 
-                    yield new GameStateEvent.Full(id, gameType, createdAt, white, black, tournamentId, state);
+                    yield new GameStateEvent.Full(id, gameType, createdAt, initialFen, white, black, tournamentId, state);
                 }
                 case "gameState" -> gameStateEventStateMapper.apply(yo);
                 case "chatLine" -> new GameStateEvent.Chat(yo.getString("username"), yo.getString("text"), yo.getString("room"));

--- a/src/main/chariot/chariot/model/GameStateEvent.java
+++ b/src/main/chariot/chariot/model/GameStateEvent.java
@@ -31,6 +31,7 @@ public sealed interface GameStateEvent {
             String id,
             GameType gameType,
             ZonedDateTime createdAt,
+            String initialFen,
             Side white,
             Side black,
             Opt<TournamentId> tournament,


### PR DESCRIPTION
Hi,

This pull request adds the *initialFen* attribute returned by [https://lichess.org/api/bot/game/stream/{gameId}](https://lichess.org/api#tag/Bot/operation/botGameStream) to GameStateEvent.Full event.

It seems it is the only way to get the initial FEN of a game (which is useful when you want to get the full history of a chess960 game after it was started. Typically to make your bot able to restart and continue to play ongoing games).  

I was hoping that GameStartEvent could help me, unfortunately its *fen* attribute does not contain the initial FEN, but the current FEN.